### PR TITLE
Remove 'T' and 'F' from list of expected boolean values

### DIFF
--- a/openfoam.py
+++ b/openfoam.py
@@ -27,14 +27,14 @@ class InputFile(object):
         ('(',')',list),
     ]
     true_values = [
-        'true','t',
+        'true',
         'on',
-        'yes','y',
+        'yes',
     ]
     false_values = [
-        'false','f',
+        'false',
         'off',
-        'no','n',
+        'no',
         'none',
     ]
 


### PR DESCRIPTION
The other values (true/false/yes/no) are more commonly used, and there
is no ambiguity between "T" (true) and "T" (temperature field)