### PR TITLE
Feature/properly read OF 

### DIFF
--- a/SOWFA6/postProcessing/averaging.py
+++ b/SOWFA6/postProcessing/averaging.py
@@ -10,16 +10,17 @@
 # specific language governing permissions and limitations under the License.
 
 """
-For processing SOWFA planar averages
-Based on original SOWFA/postProcessing/averaging.py
+For processing SOWFA-6 planar averages
+
+Based on original SOWFA/postProcessing/averaging.py from github.com/NWTC/datatools
 
 written by
-Dries Allaerts (dries.allaerts@nrel.gov)
-Eliot Quon (eliot.quon@nrel.gov)
+- Dries Allaerts (dries.allaerts@nrel.gov)
+- Eliot Quon (eliot.quon@nrel.gov)
 
 Sample usage:
 
-    from SOWFA6.postProcessing.averaging import PlanarAverages
+    from windtools.SOWFA6.postProcessing.averaging import PlanarAverages
 
     # read all time directories in current working directory
     averagingData = PlanarAverages()

--- a/SOWFA6/postProcessing/sourceHistory.py
+++ b/SOWFA6/postProcessing/sourceHistory.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 """
-For processing SOWFA driving force data in postProcessing/SourceHistory
+For processing SOWFA-6 driving force data in postProcessing/SourceHistory
 Based on averaging.py written by Eliot Quon
 
 written by Dries Allaerts (dries.allaerts@nrel.gov)
@@ -19,7 +19,7 @@ The class can handle both height-dependent and constant source files
 
 Sample usage:
 
-    from datatools.SOWFA6.postProcessing.sourceHistory import SourceHistory
+    from windtools.SOWFA6.postProcessing.sourceHistory import SourceHistory
 
     # read all time directories in current working directory or in subdirectory called 'SourceHistory'
     srcData = SourceHistory()

--- a/openfoam.py
+++ b/openfoam.py
@@ -20,7 +20,7 @@ class InputFile(dict):
     - lists
     - dictionaries
     """
-    DEBUG = True
+    DEBUG = False
 
     block_defs = [
         ('{','}',dict),
@@ -222,9 +222,13 @@ class InputFile(dict):
                 newparent = parent[name]
             else:
                 assert isinstance(parent, list)
-                if self.DEBUG:
-                    print('ADDING list item,',name)
                 # parent is a list
+                if self.DEBUG:
+                    print('ADDING list item, name=',name)
+                if name is not None:
+                    # if we have nested nists with mixed types we could
+                    # end up here...
+                    parent.append(self._try_cast(name))
                 newparent = containertype()
                 parent.append(newparent)
             newdefn = defn[1:-1].strip()

--- a/openfoam.py
+++ b/openfoam.py
@@ -25,6 +25,7 @@ class InputFile(object):
     block_defs = [
         ('{','}',dict),
         ('(',')',list),
+        ('[',']',list),
     ]
     true_values = [
         'true',

--- a/openfoam.py
+++ b/openfoam.py
@@ -195,26 +195,7 @@ class InputFile(dict):
         defn = defn.strip()
         if containertype is None:
             # set single value in parent 
-            assert(defn.find(' ') < 0)
-            try:
-                # attempt float cast
-                defn = float(defn)
-            except ValueError:
-                # THIS IS A TRAP
-                #try:
-                #    # attempt boolean cast
-                #    defn = bool(defn)
-                #except ValueError:
-                #    # default to string
-                #    pass
-                if defn.lower() in self.true_values:
-                    defn = True
-                elif defn.lower() in self.false_values:
-                    defn = False
-                else:
-                    # default to string
-                    defn = defn.strip('"')
-                    defn = defn.strip('\'')
+            defn = self._try_cast(defn)
             # SET VALUE HERE
             if self.DEBUG:
                 print(name,'-->',defn)
@@ -259,3 +240,25 @@ class InputFile(dict):
                 for newname,newdef,newcontainertype in self._split_defs(newdefn):
                     self._parse(newname,newdef,newcontainertype,parent=newparent)
 
+    def _try_cast(self,s):
+        assert(s.find(' ') < 0)
+        try:
+            # attempt float cast
+            s = float(s)
+        except ValueError:
+            # THIS IS A TRAP
+            #try:
+            #    # attempt boolean cast
+            #    s = bool(s)
+            #except ValueError:
+            #    # default to string
+            #    pass
+            if s.lower() in self.true_values:
+                s = True
+            elif s.lower() in self.false_values:
+                s = False
+            else:
+                # default to string
+                s = s.strip('"')
+                s = s.strip('\'')
+        return s

--- a/openfoam.py
+++ b/openfoam.py
@@ -12,7 +12,7 @@
 import re
 
 
-class InputFile(object):
+class InputFile(dict):
     """Object to parse and store openfoam input file data
     
     Includes support for parsing:
@@ -45,7 +45,6 @@ class InputFile(object):
     ]
 
     def __init__(self,fpath):
-        self._properties = {}
         # read full file
         with open(fpath) as f:
             lines = f.readlines()
@@ -88,7 +87,7 @@ class InputFile(object):
     def __repr__(self):
         descstrs = [
             '{:s} : {:s}'.format(key, self._format_item_str(val))
-            for key,val in self._properties.items()
+            for key,val in self.items()
         ]
         return '\n'.join(descstrs)
 
@@ -211,17 +210,18 @@ class InputFile(object):
             if self.DEBUG:
                 print(name,'-->',defn)
             if parent is None:
-                self._properties[name] = defn
+                self.__setitem__(name, defn)
             elif isinstance(parent, dict):
                 parent[name] = defn
             else:
+                assert isinstance(parent, list)
                 parent.append(defn)
         else:
             # we have a subblock, create new container
             if parent is None:
                 # parent is the InputFile object
-                self._properties[name] = containertype()
-                newparent = self._properties[name]
+                self.__setitem__(name, containertype())
+                newparent = self.__getitem__(name)
             elif isinstance(parent, dict):
                 # parent is a dictionary
                 if self.DEBUG:
@@ -246,17 +246,4 @@ class InputFile(object):
             else:
                 for newname,newdef,newcontainertype in self._split_defs(newdefn):
                     self._parse(newname,newdef,newcontainertype,parent=newparent)
-
-
-    """
-    dictionary-like functions
-    """
-    def __getitem__(self, key):
-        return self._properties[key]
-
-    def keys(self):
-        return self._properties.keys()
-
-    def items(self):
-        return self._properties.items()
 

--- a/openfoam.py
+++ b/openfoam.py
@@ -38,6 +38,11 @@ class InputFile(object):
         'no',
         'none',
     ]
+    special_keywords = [
+        'uniform',
+        'nonuniform',
+        'table',
+    ]
 
     def __init__(self,fpath):
         self._properties = {}
@@ -117,6 +122,12 @@ class InputFile(object):
                 if self.DEBUG: print('EOF',string)
             else:
                 string = txt[:idx].strip()
+                if string in self.special_keywords:
+                    name += '_'+string
+                    txt = txt[idx+1:].strip()
+                    idx = txt.find(' ')
+                    assert (idx > 0), 'problem parsing '+string+' field'
+                    string = txt[:idx].strip()
             if string.endswith(';'):
                 # found single definition
                 if self.DEBUG: print('value=',string[:-1])


### PR DESCRIPTION
Updated openfoam.InputFile() reader to properly handle files with tables (nested lists) with different types. The InputFile class is now a subclass of dict for improved dictionary functionality.

E.g., in `0.original/qwall` where the lower boundaryField may be of type `uniformFixedValue` with `uniformValue table $heatFluxHistory;`, where `heatFluxHistory` is defined as:
```
heatFluxHistory
(
    (    0 (0 0 -0.166258))
    (  600 (0 0 -0.165442))
    ( 1200 (0 0 -0.164167))
    // ...
);
```

Previous implementation resulted in empty lists appended instead of 0, 600, 1200, ...

Verified that new `InputFile()` reader produces identical output as old code for:
- setUp
- constant/ABLProperties
- system/controlDict