### PR TITLE
Improve speed of writing VTK files for postprocessing of AMRWind data 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.pyc
+windtools.egg-info

--- a/windtools/amrwind/to_fastfarm.py
+++ b/windtools/amrwind/to_fastfarm.py
@@ -1,14 +1,16 @@
 import os
 import numpy as np
-import windtools.amrwind.post_processing as pp
 import multiprocessing as mp
+from mpi4py import MPI
+
+import windtools.amrwind.post_processing as pp
 
 
-def to_ff(file_path, output_path, group_name, i_start, i_end, numcores, vtkstartind=0):
+def dristribute_nodes(
+    file_path, output_path, group_name, i_start, i_end, vtkstartind=0
+):
     """
-    An example function to write VTK files parallelly from AMR-Wind simulation.
-    This code spawns a separate process to write each VTK file.
-    The total number of parallel processes can be selected using the input `numcores'.
+    An example function to write VTK files parallelly from AMR-Wind simulation using MPI
 
     Args:
     -----
@@ -22,9 +24,6 @@ def to_ff(file_path, output_path, group_name, i_start, i_end, numcores, vtkstart
         Initial index of the VTK file to be written (This is usually )
     i_end: int
         Final index of the VTK file to be written
-    numcores: int
-        Number of parallel processes spawned at a time. This should be set to
-        the number of cores in the CPU,
     vtkstartind: int, optional, default=0
         Index by which the names of the vtk files will be shifted.
         This is useful for saving files starting from a non-zero time-step when AMR-Wind crashes
@@ -33,10 +32,10 @@ def to_ff(file_path, output_path, group_name, i_start, i_end, numcores, vtkstart
     Example:
     -------
     The function can be used as follows:
-    
+
     >>> import windtools.amrwind.to_fastfarm as tf
     >>> import time
-    >>> 
+    >>>
     >>> file_path = '../sampling_lr96000.nc'
     >>> output_path = 'output'
     >>> group_name = 'Low'
@@ -44,36 +43,62 @@ def to_ff(file_path, output_path, group_name, i_start, i_end, numcores, vtkstart
     >>> shiftind=0
     >>> i_start = 0
     >>> i_end = 7500
-    >>> 
+    >>>
     >>> startTime = time.time()
-    >>> tf.to_ff(file_path,output_path,group_name,i_start,i_end,numcores,shiftind)
+    >>> tf.distribute_nodes(file_path,output_path,group_name,i_start,i_end,shiftind)
     >>> executionTime = (time.time() - startTime)
     >>> print('Execution time in seconds: ' + str(executionTime))
 
     """
 
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    # Calculate the workload for each process
+    workpernode = (i_end - i_start + 1) // size
+    remainder = (i_end - i_start + 1) % size
+
+    # Determine the start and end indices for each process
+    start_index = i_start + rank * workpernode + min(rank, remainder)
+    end_index = start_index + workpernode + (rank < remainder)
+    print(f"The current rank is {rank}")
+    disritube_cores(
+        file_path, output_path, group_name, start_index, end_index, vtkstartind=0
+    )
+
+
+def disritube_cores(file_path, output_path, group_name, i_start, i_end, vtkstartind=0):
+
+    # Find number of cores
+    numcores = mp.cpu_count()
+    # numcores = 2
+
     # Read sample and prints the groups contained in it
     sample = pp.Sampling(file_path)
     print(sample)
     group_path = os.path.join(output_path, group_name)
+    # dst1 = sample.read_single_group('Low')
 
     # numbatches is the number of batches of `numcores` processes that will be spawned
     numbatches = (i_end - i_start + 1) // numcores + 1
 
     for batchi in np.arange(numbatches):
-        Proc_all = []   # List to stores all the processes for a batch.
+        Proc_all = []  # List to stores all the processes for a batch.
         for corei in np.arange(numcores):
-            ind = batchi * numcores + corei + i_start   # Index of the VTK file to be written
-            if ind > i_end:                             # Don't spawn more processes if last index is reached
+            ind = (
+                batchi * numcores + corei + i_start
+            )  # Index of the VTK file to be written
+            if ind > i_end:  # Don't spawn more processes if last index is reached
                 break
-            
+
             # Spawn one process for each index
             p = mp.Process(
                 target=parfunc,
                 args=(sample, group_name, group_path, ind, ind + 1, vtkstartind),
             )
 
-            # Start the process 
+            # Start the process
             p.start()
 
             # Store all the processes spawned in a batch in a list
@@ -93,4 +118,5 @@ def parfunc(sample, dataset, group_path, ind_i, ind_f, vtkstartind):
         itime_i=ind_i,
         itime_f=ind_f,
         vtkstartind=vtkstartind,
+        verbose=False,
     )

--- a/windtools/amrwind/to_fastfarm.py
+++ b/windtools/amrwind/to_fastfarm.py
@@ -6,7 +6,7 @@ from mpi4py import MPI
 import windtools.amrwind.post_processing as pp
 
 
-def dristribute_nodes(
+def distribute_nodes(
     file_path, output_path, group_name, i_start, i_end, vtkstartind=0
 ):
     """
@@ -39,7 +39,6 @@ def dristribute_nodes(
     >>> file_path = '../sampling_lr96000.nc'
     >>> output_path = 'output'
     >>> group_name = 'Low'
-    >>> numcores = 36
     >>> shiftind=0
     >>> i_start = 0
     >>> i_end = 7500
@@ -63,12 +62,12 @@ def dristribute_nodes(
     start_index = i_start + rank * workpernode + min(rank, remainder)
     end_index = start_index + workpernode + (rank < remainder)
     print(f"The current rank is {rank}")
-    disritube_cores(
-        file_path, output_path, group_name, start_index, end_index, vtkstartind=0
+    distribute_cores(
+        file_path, output_path, group_name, start_index, end_index, vtkstartind
     )
 
 
-def disritube_cores(file_path, output_path, group_name, i_start, i_end, vtkstartind=0):
+def distribute_cores(file_path, output_path, group_name, i_start, i_end, vtkstartind=0):
 
     # Find number of cores
     numcores = mp.cpu_count()
@@ -89,10 +88,11 @@ def disritube_cores(file_path, output_path, group_name, i_start, i_end, vtkstart
             ind = (
                 batchi * numcores + corei + i_start
             )  # Index of the VTK file to be written
-            if ind > i_end:  # Don't spawn more processes if last index is reached
+            if ind >= i_end:  # Don't spawn more processes if last index is reached
                 break
 
             # Spawn one process for each index
+            # parfunc(sample, group_name, group_path, ind, ind + 1, vtkstartind)
             p = mp.Process(
                 target=parfunc,
                 args=(sample, group_name, group_path, ind, ind + 1, vtkstartind),

--- a/windtools/amrwind/to_fastfarm.py
+++ b/windtools/amrwind/to_fastfarm.py
@@ -1,0 +1,46 @@
+import os
+import numpy as np
+import windtools.amrwind.post_processing as pp
+import multiprocessing as mp
+
+def to_ff(file_path,output_path,group_name,i_start,i_end,numcores,vtkstartind=0):
+    '''
+    An example function to write VTK files parallelly from AMR-Wind simulation.
+    This code swapns a separate process to write each VTK file.
+    The total number of parallel 
+    
+    Parameters:- 
+    file_path: Path of the .nc file to be read
+    output_path: Directory containing the groupwise folder where VTK files should be written
+    group_name: Name of the group to be converted to VTK
+    i_start: Initial index of the VTK file to be written (This is usually )
+    i_end: Final index of the VTK file to be written
+    numcores: Number of parallel processes spawned at a time. This should be set to 
+        the number of cores in the CPU,
+    vtkstartind: Index by which the names of the vtk files will be shifted. 
+        This is useful for saving files starting from a non-zero time-step when AMR-Wind crashes
+        unxpectedly and is restarted using a savefile.
+    '''
+
+    sample = pp.Sampling(file_path)
+    print(sample)
+    group_path = os.path.join(output_path,group_name)
+
+    #     
+    numbatches =  (i_end-i_start+1)//numcores+1
+    for batchi in np.arange(numbatches):
+        Proc_all = []
+        for corei in np.arange(numcores):
+            ind = batchi*numcores + corei + i_start
+            print(ind)
+            if ind>i_end:
+                break
+            p = mp.Process(target=parfunc,args=(sample,group_name,group_path,ind,ind+1,vtkstartind))
+            p.start()
+            Proc_all.append(p)
+        for p in Proc_all:
+            p.join()
+            
+def parfunc(sample,dataset,group_path,ind_i,ind_f,vtkstartind):
+    #Function to be called by each script
+    sample.to_vtk(dataset,group_path,offsetz=0, itime_i=ind_i,itime_f=ind_f,vtkstartind=vtkstartind)

--- a/windtools/amrwind/to_fastfarm.py
+++ b/windtools/amrwind/to_fastfarm.py
@@ -3,44 +3,94 @@ import numpy as np
 import windtools.amrwind.post_processing as pp
 import multiprocessing as mp
 
-def to_ff(file_path,output_path,group_name,i_start,i_end,numcores,vtkstartind=0):
-    '''
+
+def to_ff(file_path, output_path, group_name, i_start, i_end, numcores, vtkstartind=0):
+    """
     An example function to write VTK files parallelly from AMR-Wind simulation.
-    This code swapns a separate process to write each VTK file.
-    The total number of parallel 
-    
-    Parameters:- 
-    file_path: Path of the .nc file to be read
-    output_path: Directory containing the groupwise folder where VTK files should be written
-    group_name: Name of the group to be converted to VTK
-    i_start: Initial index of the VTK file to be written (This is usually )
-    i_end: Final index of the VTK file to be written
-    numcores: Number of parallel processes spawned at a time. This should be set to 
+    This code spawns a separate process to write each VTK file.
+    The total number of parallel processes can be selected using the input `numcores'.
+
+    Args:
+    -----
+    file_path: str
+        Path of the .nc file to be read
+    output_path: str
+        Directory containing the groupwise folder where VTK files should be written
+    group_name: str
+        Name of the group to be converted to VTK
+    i_start: int
+        Initial index of the VTK file to be written (This is usually )
+    i_end: int
+        Final index of the VTK file to be written
+    numcores: int
+        Number of parallel processes spawned at a time. This should be set to
         the number of cores in the CPU,
-    vtkstartind: Index by which the names of the vtk files will be shifted. 
+    vtkstartind: int, optional, default=0
+        Index by which the names of the vtk files will be shifted.
         This is useful for saving files starting from a non-zero time-step when AMR-Wind crashes
         unxpectedly and is restarted using a savefile.
-    '''
 
+    Example:
+    -------
+    The function can be used as follows:
+    
+    >>> import windtools.amrwind.to_fastfarm as tf
+    >>> import time
+    >>> 
+    >>> file_path = '../sampling_lr96000.nc'
+    >>> output_path = 'output'
+    >>> group_name = 'Low'
+    >>> numcores = 36
+    >>> shiftind=0
+    >>> i_start = 0
+    >>> i_end = 7500
+    >>> 
+    >>> startTime = time.time()
+    >>> tf.to_ff(file_path,output_path,group_name,i_start,i_end,numcores,shiftind)
+    >>> executionTime = (time.time() - startTime)
+    >>> print('Execution time in seconds: ' + str(executionTime))
+
+    """
+
+    # Read sample and prints the groups contained in it
     sample = pp.Sampling(file_path)
     print(sample)
-    group_path = os.path.join(output_path,group_name)
+    group_path = os.path.join(output_path, group_name)
 
-    #     
-    numbatches =  (i_end-i_start+1)//numcores+1
+    # numbatches is the number of batches of `numcores` processes that will be spawned
+    numbatches = (i_end - i_start + 1) // numcores + 1
+
     for batchi in np.arange(numbatches):
-        Proc_all = []
+        Proc_all = []   # List to stores all the processes for a batch.
         for corei in np.arange(numcores):
-            ind = batchi*numcores + corei + i_start
-            print(ind)
-            if ind>i_end:
+            ind = batchi * numcores + corei + i_start   # Index of the VTK file to be written
+            if ind > i_end:                             # Don't spawn more processes if last index is reached
                 break
-            p = mp.Process(target=parfunc,args=(sample,group_name,group_path,ind,ind+1,vtkstartind))
+            
+            # Spawn one process for each index
+            p = mp.Process(
+                target=parfunc,
+                args=(sample, group_name, group_path, ind, ind + 1, vtkstartind),
+            )
+
+            # Start the process 
             p.start()
+
+            # Store all the processes spawned in a batch in a list
             Proc_all.append(p)
+
+        # Only move the the next batch after all the processes of the current batch are completed
         for p in Proc_all:
             p.join()
-            
-def parfunc(sample,dataset,group_path,ind_i,ind_f,vtkstartind):
-    #Function to be called by each script
-    sample.to_vtk(dataset,group_path,offsetz=0, itime_i=ind_i,itime_f=ind_f,vtkstartind=vtkstartind)
+
+
+def parfunc(sample, dataset, group_path, ind_i, ind_f, vtkstartind):
+    # Function to be called by each process spawned
+    sample.to_vtk(
+        dataset,
+        group_path,
+        offsetz=0,
+        itime_i=ind_i,
+        itime_f=ind_f,
+        vtkstartind=vtkstartind,
+    )


### PR DESCRIPTION
This pull request improves the process and speed of writing of VTK files for post processing of AMR-Wind data.
The pull request has following changes

Minor changes: 
- [ ] Add windtools.egg-info in [`.gitignore`](https://github.com/NREL/windtools/compare/master...abhineet-gupta:AG_windtools:amrpost?expand=1#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) file
- [ ] Add a new parameter `vtkstartind` in `to_vtk` method of `sampling` class in [`post_processing.py`](https://github.com/NREL/windtools/compare/master...abhineet-gupta:AG_windtools:amrpost?expand=1#diff-ca459be23bacf20c8a01c2bd13a217296bb099a7bf0fd5a693b8dbbdf0955afc) which is useful to correctly name the VTK files when AMR-Wind simulation is restarted from a checkpoint.

Major changes:
- [ ] Vectorize the writing of the VKT files instead of using loops. This resultsa in a significant improvement in the speed at [`post_processing.py`](https://github.com/NREL/windtools/compare/master...abhineet-gupta:AG_windtools:amrpost?expand=1#diff-ca459be23bacf20c8a01c2bd13a217296bb099a7bf0fd5a693b8dbbdf0955afc)
- [ ] Add an example script [`to_fastfarm.py`](https://github.com/NREL/windtools/compare/master...abhineet-gupta:AG_windtools:amrpost?expand=1#diff-c1fd12af7ed55a21195348573f2dc863b2764d4af659cc61e346369799948f3d) to write VTK files in a parallelly to further improve the speed.

