### PR TITLE
Update ABL stats reader

### DIFF
--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -23,6 +23,7 @@ class ABLStatistics(object):
         self._load_timeseries()
         if mean_profiles:
             self._load_timeheight_profiles()
+            self._calc_total_fluxes()
         self.t = self.ds.coords['time']
         self.z = self.ds.coords['height']
 
@@ -54,6 +55,14 @@ class ABLStatistics(object):
         ds = ds.transpose(self.time_coord,'height')
         self.ds = xr.combine_by_coords([self.ds, ds])
         self.ds[self.time_coord] = np.round(self.ds[self.time_coord],5)
+
+    def _calc_total_fluxes(self):
+        for varn in self.ds.data_vars:
+            if varn.endswith('_r'):
+                varn_sfs = varn[:-2] + '_sfs'
+                if varn_sfs in self.ds.data_vars:
+                    varn_tot = varn[:-2] + '_tot'
+                    self.ds[varn_tot] = self.ds[varn] + self.ds[varn_sfs]
 
     def rolling_mean(self,Tavg=3600.):
         dt = float(self.t[1] - self.t[0])

--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -23,6 +23,8 @@ class ABLStatistics(object):
         self._load_timeseries()
         if mean_profiles:
             self._load_timeheight_profiles()
+        self.t = self.ds.coords['time']
+        self.z = self.ds.coords['height']
 
     def _setup_time_coords(self,ds):
         if self.datetime0:
@@ -53,8 +55,12 @@ class ABLStatistics(object):
         self.ds = xr.combine_by_coords([self.ds, ds])
         self.ds[self.time_coord] = np.round(self.ds[self.time_coord],5)
 
-
-
+    def rolling_mean(self,Tavg=3600.):
+        dt = float(self.t[1] - self.t[0])
+        assert np.all(np.diff(self.t) == dt), 'Output time interval is variable'
+        Navg = int(Tavg / dt)
+        assert Navg > 0
+        return self.ds.rolling(time=Navg).mean()
 
 
 class Sampling(object):

--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -24,6 +24,7 @@ class ABLStatistics(object):
         if mean_profiles:
             self._load_timeheight_profiles()
             self._calc_total_fluxes()
+            self._calc_TI()
         self.t = self.ds.coords['time']
         self.z = self.ds.coords['height']
 
@@ -63,6 +64,13 @@ class ABLStatistics(object):
                 if varn_sfs in self.ds.data_vars:
                     varn_tot = varn[:-2] + '_tot'
                     self.ds[varn_tot] = self.ds[varn] + self.ds[varn_sfs]
+
+    def _calc_TI(self):
+        ang = np.arctan2(self.ds['v'], self.ds['u'])
+        rotatedvar = self.ds["u'u'_r"] * np.cos(ang)**2 \
+                   + self.ds["u'v'_r"] * 2*np.sin(ang)*np.cos(ang) \
+                   + self.ds["v'v'_r"] * np.sin(ang)**2
+        self.ds['TI'] = np.sqrt(rotatedvar) / self.ds['hvelmag']
 
     def rolling_mean(self,Tavg=3600.):
         dt = float(self.t[1] - self.t[0])
@@ -659,10 +667,3 @@ def addDatetime(ds,dt,origin=pd.to_datetime('2000-01-01 00:00:00'), computemean=
         ds['wp'] = ds['w'] - meanw
 
     return ds
-
-
-
-
-
-
-

--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -9,6 +9,12 @@ from netCDF4 import Dataset
 class ABLStatistics(object):
 
     def __init__(self,fpath,start_date=None,mean_profiles=False):
+        """Load planar averaged ABL statistics into an underlying xarray
+        dataset for analysis. By default, only surface time histories
+        are loaded; setting `mean_profiles=True` will also load
+        time--height data from the "mean_profiles" group within the
+        dataset.
+        """
         self.fpath = fpath
         if start_date:
             self.datetime0 = pd.to_datetime(start_date)

--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -94,6 +94,9 @@ class ABLStatistics(object):
                    + self.ds["v'v'_r"] * np.sin(ang)**2
         self.ds['TI'] = np.sqrt(rotatedvar) / self.ds['hvelmag']
 
+    def __getitem__(self,key):
+        return self.ds[key]
+
     def rolling_mean(self,Tavg=3600.):
         dt = float(self.t[1] - self.t[0])
         assert np.all(np.diff(self.t) == dt), 'Output time interval is variable'

--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -21,11 +21,11 @@ class ABLStatistics(object):
         else:
             self.datetime0 = None
         self._load_timeseries(mean_profiles)
+        self.t = self.ds.coords['time']
         if mean_profiles:
+            self.z = self.ds.coords['height']
             self._calc_total_fluxes()
             self._calc_TI()
-        self.t = self.ds.coords['time']
-        self.z = self.ds.coords['height']
 
     def _check_fpaths(self,fpath):
         assert isinstance(fpath, (str,list,tuple))


### PR DESCRIPTION
* Can read multiple stats files in one go
* For convenience, automatically calculate total turbulent fluxes and TI
* Get space-time average with `ABLStatistics.rolling_mean(Tavg)` — can be useful for checking convergence