### PR TITLE
Add labels to subplots; improve VTK handling

### DIFF
--- a/windtools/amrwind/post_processing.py
+++ b/windtools/amrwind/post_processing.py
@@ -144,7 +144,7 @@ class Sampling(object):
 
         return ds_all
 
-    def read_single_group(self, group, itime=0, ftime=-1, step=1, outputPath=None, var=['u','v','w'], simCompleted=False, verbose=False, package='xr'):
+    def read_single_group(self, group, itime=0, ftime=-1, step=1, outputPath=None, var=['velocityx','velocityy','velocityz'], simCompleted=False, verbose=False, package='xr'):
 
         if package == 'xr':
             print(f'Reading single group using xarray. This will take longer and require more RAM')
@@ -160,7 +160,7 @@ class Sampling(object):
 
 
 
-    def read_single_group_h5py(self, group, itime=0, ftime=-1, step=1, outputPath=None, var=['u','v','w'], simCompleted=False, verbose=False):
+    def read_single_group_h5py(self, group, itime=0, ftime=-1, step=1, outputPath=None, var=['velocityx','velocityy','velocityz'], simCompleted=False, verbose=False):
         '''
 
         step: int
@@ -172,7 +172,7 @@ class Sampling(object):
             files will be saved.
         var: str, list of str
             variables to be outputted. By defaul, u, v, w. If temperature and tke are available,
-            use either var='all' or var=['u','v','w','tke'], for example.
+            use either var='all' or var=['velocityx','velocityy','velocityz','tke'], for example.
         simCompleted: bool, default False
             If the simulation is still running, the nc file needs to be open using `load_dataset`. 
             This function does _not_ load the data lazily, so it is prohibitively expensive to use
@@ -194,7 +194,7 @@ class Sampling(object):
 
         if isinstance(var,str): var = [var]
         if var==['all']:
-            self.reqvars = ['u','v','w','temperature','tke']
+            self.reqvars = ['velocityx','velocityy','velocityz','temperature','tke']
         else:
             self.reqvars = var
 
@@ -216,7 +216,7 @@ class Sampling(object):
 
 
 
-    def read_single_group_xr(self, group, itime=0, ftime=-1, step=1, outputPath=None, var=['u','v','w'], simCompleted=False, verbose=False):
+    def read_single_group_xr(self, group, itime=0, ftime=-1, step=1, outputPath=None, var=['velocityx','velocityy','velocityz'], simCompleted=False, verbose=False):
         
         if simCompleted:
             dsraw = xr.open_dataset(self.fpath, group=group, engine='netcdf4')
@@ -226,7 +226,7 @@ class Sampling(object):
 
         if isinstance(var,str): var = [var]
         if var==['all']:
-            self.reqvars = ['u','v','w','temperature','tke']
+            self.reqvars = ['velocityx','velocityy','velocityz','temperature','tke']
         else:
             self.reqvars = var
 
@@ -339,6 +339,8 @@ class Sampling(object):
         if ftime == -1:
             ftime = self.ndt
 
+        # Get velocity info (regardless if asked for)
+
         # Unformatted arrays
         velx_old_all = ds['velocityx'].isel(num_time_steps=slice(itime, ftime, step)).values
         vely_old_all = ds['velocityy'].isel(num_time_steps=slice(itime, ftime, step)).values
@@ -372,15 +374,36 @@ class Sampling(object):
         new_all['v'] = (ordereddims, vely_all)
         new_all['w'] = (ordereddims, velz_all)
 
-        if 'temperature' in list(ds.keys()) and 'temperature' in self.reqvars:
-            temp_old_all = ds['temperature'].isel(num_time_steps=slice(itime, ftime, step)).values
-            temp_all = np.reshape(temp_old_all, (ndt, self.nz, self.ny, self.nx)).T
-            new_all['temperature'] = (ordereddims, temp_all)
 
-        if 'tke' in list(ds.keys()) and 'tke' in self.reqvars:
-            tke_old_all = ds['tke'].isel(num_time_steps=slice(itime, ftime, step)).values
-            tke_all = np.reshape(tke_old_all, (ndt, self.nz, self.ny, self.nx)).T
-            new_all['tke'] = (ordereddims, tke_all)
+
+
+
+        print(f'The following variables are available in this dataset: {list(ds.keys())}')
+
+        for curr_var in set(self.reqvars) - {'velocityx', 'velocityy', 'velocityz'}:
+            if curr_var not in list(ds.keys()):
+                print(f'Variable {curr_var} not available. Skipping it. Available variables: {list(ds.keys())}')
+                continue
+
+            temp_old_all = ds[curr_var].isel(num_time_steps=slice(itime, ftime, step)).values
+            temp_all = np.reshape(temp_old_all, (ndt, self.nz, self.ny, self.nx)).T
+            new_all[curr_var] = (ordereddims, temp_all)
+
+
+        #if 'actuator_src_termx' in list(ds.keys()) and 'actuator_src_termx' in self.reqvars:
+        #    temp_old_all = ds['actuator_src_termx'].isel(num_time_steps=slice(itime, ftime, step)).values
+        #    temp_all = np.reshape(temp_old_all, (ndt, self.nz, self.ny, self.nx)).T
+        #    new_all['actuator_src_termx'] = (ordereddims, temp_all)
+
+        #if 'temperature' in list(ds.keys()) and 'temperature' in self.reqvars:
+        #    temp_old_all = ds['temperature'].isel(num_time_steps=slice(itime, ftime, step)).values
+        #    temp_all = np.reshape(temp_old_all, (ndt, self.nz, self.ny, self.nx)).T
+        #    new_all['temperature'] = (ordereddims, temp_all)
+
+        #if 'tke' in list(ds.keys()) and 'tke' in self.reqvars:
+        #    tke_old_all = ds['tke'].isel(num_time_steps=slice(itime, ftime, step)).values
+        #    tke_all = np.reshape(tke_old_all, (ndt, self.nz, self.ny, self.nx)).T
+        #    new_all['tke'] = (ordereddims, tke_all)
 
         if outputPath is not None:
             if outputPath.endswith('.zarr'):
@@ -489,7 +512,7 @@ class Sampling(object):
 
 
 
-    def to_vtk(self, dsOrGroup, outputPath, verbose=True, offsetz=0, itime_i=0, itime_f=-1, t0=None, dt=None, vtkstartind=0):
+    def to_vtk(self, dsOrGroup, outputPath, verbose=True, offsetz=0, itime_i=0, itime_f=-1, t0=None, dt=None, vtkstartind=0, terrain=False):
         '''
         Writes VTKs for all time stamps present in ds
 
@@ -517,10 +540,19 @@ class Sampling(object):
             Index by which the names of the vtk files will be shifted. This is useful for saving files
             starting from a non-zero time-step when AMR-Wind crashes unxpectedly and is restarted using
             a savefile.
+        terrain: bool
+            Whether or not put NaNs where the terrain is. For this option to be enabled, the dataset
+            should also contain a variable called `terrainBlank` taking the value of 1 when it's terrain
+            and 0 when it's not. This variable will dictate the velocity values that will become NaNs.
 
         '''
         if not os.path.exists(outputPath):
             raise ValueError(f'The output path should exist. Stopping.')
+
+        if terrain:
+            var = ['velocityx','velocityy','velocityz','terrainBlank']
+        else:
+            var = ['velocityx','velocityy','velocityz']
 
         if isinstance(dsOrGroup,xr.Dataset):
             ds = dsOrGroup
@@ -531,15 +563,17 @@ class Sampling(object):
         else:
             if verbose: print(f'    Reading group {dsOrGroup}, from sampling time step {itime_i} to {itime_f}...', flush=True)
             ds = self.read_single_group(dsOrGroup, itime=itime_i, ftime=itime_f, outputPath=None,
-                                        simCompleted=True, verbose=verbose)
+                                        simCompleted=True, verbose=verbose, var=var)
             if verbose: print(f'    Done reading group {dsOrGroup}, from sampling time steps above.', flush=True)
             ndt = len(ds.samplingtimestep)  # rt mar13: I had ds.num_time_steps here, but it kept crashing 
-            #xarray = self.x
-            #yarray = self.y
-            #zarray = self.z
             xarray = ds.x
             yarray = ds.y
             zarray = ds.z
+
+        if terrain:
+            ds['u'] = ds['u'].where(ds['terrainBlank'] == 0, np.nan)
+            ds['v'] = ds['v'].where(ds['terrainBlank'] == 0, np.nan)
+            ds['w'] = ds['w'].where(ds['terrainBlank'] == 0, np.nan)
 
         if t0 is None and dt is None:
             timegiven=False
@@ -597,6 +631,7 @@ class Sampling(object):
                 # Write the reshaped numpy array to the file
                 np.savetxt(vtk,np.stack((uval,vval,wval)).transpose(),fmt='%.5f',delimiter='\t',newline='\n',encoding='utf-8')
 
+        return ds
 
 def addDatetime(ds,dt,origin=pd.to_datetime('2000-01-01 00:00:00'), computemean=True):
     '''

--- a/windtools/plotting.py
+++ b/windtools/plotting.py
@@ -1235,6 +1235,50 @@ def plot_spectrum(datasets,
 #
 # ---------------------------------------------
 
+def addLabels(axs,loc='upper right', fontsize=14, alpha=0.6, pad=6, start='a'):
+    '''
+    Adds label to subfigures.
+
+    Inputs
+    ------
+    axs: axis object
+        Axis to apply the label on. Can be of any shape and dimension
+    loc: str
+        Location of the labels
+    fontsize: scalar
+        Font size
+    alpha: scalar
+        Alpha value
+    pad: int
+        Distance from corner for label. pad=0 is label touching the corner of the plot
+    start: char
+        Character in which to start labeling the subplots
+    '''
+
+    # Ensure axs is iterable
+    axs = np.array(axs)
+    
+    if   loc == 'upper right':  xy=(1,1); xytext=(-pad,-pad); xloc, yloc = 0.97, 0.97;  ha='right'; va='top'
+    elif loc == 'upper left' :  xy=(0,1); xytext=( pad,-pad); xloc, yloc = 0.03, 0.97;  ha='left';  va='top'
+    elif loc == 'lower right':  xy=(1,0); xytext=(-pad, pad); xloc, yloc = 0.97, 0.03;  ha='right'; va='bottom'
+    elif loc == 'lower left' :  xy=(0,0); xytext=( pad, pad); xloc, yloc = 0.03, 0.03;  ha='left';  va='bottom'
+    else:
+        raise ValueError('loc not recognized. Stopping.')
+    
+    labels = list(map(chr, range(ord(start), 123)))
+    if len(axs.flatten()) > len(labels):
+        # More than a--z, so create 1a, 1b, 1c, 2a, etc. First find the number of numbers number of letters
+        nN = np.shape(axs)[0]
+        nL = np.shape(axs)[1]
+        labels = [str(number) + chr(ord('a') + iletter) for number in range(1, nN + 1) for iletter in range(nL)]
+
+    props = dict(facecolor='white', alpha=alpha, edgecolor='silver', boxstyle='square', pad=0.15)
+    
+    for i, ax in enumerate(axs.flatten()):
+        ax.annotate(f'$({labels[i]})$', xy=xy, color='black', ha=ha, va=va, xycoords='axes fraction',
+                    xytext=xytext, textcoords='offset points', fontsize=fontsize, bbox=props)
+
+
 class InputError(Exception):
     """Exception raised for errors in the input.
 

--- a/windtools/plotting.py
+++ b/windtools/plotting.py
@@ -172,10 +172,14 @@ def plot_timeheight(datasets,
         Custom field labels. If only one field is plotted, fieldlabels
         can be a string. Otherwise it should be a dictionary with
         entries <fieldname>: fieldlabel
-    labelsubplots : bool, list or tuple
-        Label subplots as (a), (b), (c), ... If a list or tuple is given
-        their values should be the horizontal and vertical position 
-        relative to each subaxis.
+    labelsubplots : bool, dict, string, or list-like
+        Label subplots as (a), (b), (c), ... If set to True, then labels
+        will be created inside of axes with default options (see the
+        `addLabels` function). If a dictionary is provided, then this is
+        passed to `addLabels`. Alternatively, labels may be placed
+        outside of axes by specifying 'outside'. If a list or tuple is
+        given, their values should be the horizontal and vertical
+        position of the outside label, relative to each subaxis.
     showcolorbars : bool
         Show colorbar per subplot
     fieldorder : 'C' or 'F'
@@ -352,16 +356,21 @@ def plot_timeheight(datasets,
     
     # Number sub figures as a, b, c, ...
     if labelsubplots is not False:
-        addLabels(axv)
-
-        # 2023-09-25: commenting this out and using my implementation
-        # of labeling subplots (above)
-        #try:
-        #    hoffset, voffset = labelsubplots
-        #except (TypeError, ValueError):
-        #    hoffset, voffset = -0.14, 1.0
-        #for i,axi in enumerate(axv):
-        #    axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
+        if labelsubplots is True:
+            # default inside labels
+            addLabels(axv)
+        elif isinstance(labelsubplots,dict):
+            addLabels(axv,**labelsubplots)
+        elif isinstance(labelsubplots,(str,list,tuple)):
+            try:
+                hoffset, voffset = labelsubplots
+            except (TypeError, ValueError):
+                assert labelsubplots.lower == 'outside', \
+                        'Unexpected labelsubplots specification'
+                # default outside labels
+                hoffset, voffset = -0.14, 1.0
+            for i,axi in enumerate(axv):
+                axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
 
     # Return cbar instead of array if ntotal==1
     if len(cbars)==1:
@@ -443,10 +452,14 @@ def plot_timehistory_at_height(datasets,
         If True, stack datasets together, otherwise stack by heights. If
         None, stack_by_datasets will be set based on the number of heights
         and datasets. 
-    labelsubplots : bool, list or tuple
-        Label subplots as (a), (b), (c), ... If a list or tuple is given
-        their values should be the horizontal and vertical position 
-        relative to each subaxis.
+    labelsubplots : bool, dict, string, or list-like
+        Label subplots as (a), (b), (c), ... If set to True, then labels
+        will be created inside of axes with default options (see the
+        `addLabels` function). If a dictionary is provided, then this is
+        passed to `addLabels`. Alternatively, labels may be placed
+        outside of axes by specifying 'outside'. If a list or tuple is
+        given, their values should be the horizontal and vertical
+        position of the outside label, relative to each subaxis.
     showlegend : bool (or None)
         Label different plots and show legend. If None, showlegend is set
         to True if legend will have more than one entry, otherwise it is
@@ -666,16 +679,21 @@ def plot_timehistory_at_height(datasets,
 
     # Number sub figures as a, b, c, ...
     if labelsubplots is not False:
-        addLabels(axv)
-
-        # 2023-09-25: commenting this out and using my implementation
-        # of labeling subplots (above)
-        #try:
-        #    hoffset, voffset = labelsubplots
-        #except (TypeError, ValueError):
-        #    hoffset, voffset = -0.14, 1.0
-        #for i,axi in enumerate(axv):
-        #    axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
+        if labelsubplots is True:
+            # default inside labels
+            addLabels(axv)
+        elif isinstance(labelsubplots,dict):
+            addLabels(axv,**labelsubplots)
+        elif isinstance(labelsubplots,(str,list,tuple)):
+            try:
+                hoffset, voffset = labelsubplots
+            except (TypeError, ValueError):
+                assert labelsubplots.lower == 'outside', \
+                        'Unexpected labelsubplots specification'
+                # default outside labels
+                hoffset, voffset = -0.14, 1.0
+            for i,axi in enumerate(axv):
+                axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
 
     # Add legend
     if showlegend:
@@ -761,10 +779,14 @@ def plot_profile(datasets,
         If True, stack datasets together, otherwise stack by times. If
         None, stack_by_datasets will be set based on the number of times
         and datasets. 
-    labelsubplots : bool, list or tuple
-        Label subplots as (a), (b), (c), ... If a list or tuple is given
-        their values should be the horizontal and vertical position 
-        relative to each subaxis.
+    labelsubplots : bool, dict, string, or list-like
+        Label subplots as (a), (b), (c), ... If set to True, then labels
+        will be created inside of axes with default options (see the
+        `addLabels` function). If a dictionary is provided, then this is
+        passed to `addLabels`. Alternatively, labels may be placed
+        outside of axes by specifying 'outside'. If a list or tuple is
+        given, their values should be the horizontal and vertical
+        position of the outside label, relative to each subaxis.
     showlegend : bool (or None)
         Label different plots and show legend. If None, showlegend is set
         to True if legend will have more than one entry, otherwise it is
@@ -998,16 +1020,21 @@ def plot_profile(datasets,
     
     # Number sub figures as a, b, c, ...
     if labelsubplots is not False:
-        addLabels(axv)
-
-        # 2023-09-25: commenting this out and using my implementation
-        # of labeling subplots (above)
-        #try:
-        #    hoffset, voffset = labelsubplots
-        #except (TypeError, ValueError):
-        #    hoffset, voffset = -0.14, -0.18
-        #for i,axi in enumerate(axv):
-        #    axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
+        if labelsubplots is True:
+            # default inside labels
+            addLabels(axv)
+        elif isinstance(labelsubplots,dict):
+            addLabels(axv,**labelsubplots)
+        elif isinstance(labelsubplots,(str,list,tuple)):
+            try:
+                hoffset, voffset = labelsubplots
+            except (TypeError, ValueError):
+                assert labelsubplots.lower == 'outside', \
+                        'Unexpected labelsubplots specification'
+                # default outside labels
+                hoffset, voffset = -0.14, -0.18
+            for i,axi in enumerate(axv):
+                axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
     
     # Add legend
     if showlegend:
@@ -1074,10 +1101,14 @@ def plot_spectrum(datasets,
         Custom field labels. If only one field is plotted, fieldlabels
         can be a string. Otherwise it should be a dictionary with
         entries <fieldname>: fieldlabel
-    labelsubplots : bool, list or tuple
-        Label subplots as (a), (b), (c), ... If a list or tuple is given
-        their values should be the horizontal and vertical position 
-        relative to each subaxis.
+    labelsubplots : bool, dict, string, or list-like
+        Label subplots as (a), (b), (c), ... If set to True, then labels
+        will be created inside of axes with default options (see the
+        `addLabels` function). If a dictionary is provided, then this is
+        passed to `addLabels`. Alternatively, labels may be placed
+        outside of axes by specifying 'outside'. If a list or tuple is
+        given, their values should be the horizontal and vertical
+        position of the outside label, relative to each subaxis.
     showlegend : bool (or None)
         Label different plots and show legend. If None, showlegend is set
         to True if legend will have more than one entry, otherwise it is
@@ -1213,12 +1244,21 @@ def plot_spectrum(datasets,
 
     # Number sub figures as a, b, c, ...
     if labelsubplots is not False:
-        try:
-            hoffset, voffset = labelsubplots
-        except (TypeError, ValueError):
-            hoffset, voffset = -0.14, -0.18
-        for i,axi in enumerate(axv):
-            axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
+        if labelsubplots is True:
+            # default inside labels
+            addLabels(axv)
+        elif isinstance(labelsubplots,dict):
+            addLabels(axv,**labelsubplots)
+        elif isinstance(labelsubplots,(str,list,tuple)):
+            try:
+                hoffset, voffset = labelsubplots
+            except (TypeError, ValueError):
+                assert labelsubplots.lower == 'outside', \
+                        'Unexpected labelsubplots specification'
+                # default outside labels
+                hoffset, voffset = -0.14, -0.18
+            for i,axi in enumerate(axv):
+                axi.text(hoffset,voffset,'('+chr(i+97)+')',transform=axi.transAxes,size=16)
 
     # Add legend
     if showlegend:

--- a/windtools/plotting.py
+++ b/windtools/plotting.py
@@ -66,6 +66,7 @@ fieldlabels_default_units = {
     'sigma_w/calc_u*': r'$\sigma_w/u_*$',
     'sigma_v/sigma_u': r'$\sigma_v/\sigma_u$',
     'sigma_w/sigma_u': r'$\sigma_w/\sigma_u$',
+    'Phi_m': r'$\Phi_m = \kappa z/u_* \frac{\partial U}{\partial z}$',
 }
 fieldlabels_superscript_units = {
     'wspd': r'Wind speed [m s$^{-1}$]',

--- a/windtools/plotting.py
+++ b/windtools/plotting.py
@@ -26,8 +26,6 @@ from scipy.interpolate import interp1d
 from scipy.signal import welch
 
 import os, sys
-sys.path.append(os.path.abspath('/home/rthedin/utilities/'))
-from helper import addLabels
 
 # Standard field labels
 # - default: e.g., "Km/s"

--- a/windtools/plotting.py
+++ b/windtools/plotting.py
@@ -1233,7 +1233,7 @@ def plot_spectrum(datasets,
 #
 # ---------------------------------------------
 
-def addLabels(axs,loc='upper right', fontsize=14, alpha=0.6, pad=6, start='a'):
+def addLabels(axs,loc='upper right', fontsize=14, alpha=0.6, pad=6, start='a', **bbox_props):
     '''
     Adds label to subfigures.
 
@@ -1271,6 +1271,8 @@ def addLabels(axs,loc='upper right', fontsize=14, alpha=0.6, pad=6, start='a'):
         labels = [str(number) + chr(ord('a') + iletter) for number in range(1, nN + 1) for iletter in range(nL)]
 
     props = dict(facecolor='white', alpha=alpha, edgecolor='silver', boxstyle='square', pad=0.15)
+    for key,val in bbox_props.items():
+        props[key] = val
     
     for i, ax in enumerate(axs.flatten()):
         ax.annotate(f'$({labels[i]})$', xy=xy, color='black', ha=ha, va=va, xycoords='axes fraction',


### PR DESCRIPTION
This PR has two features:

1. Simple addition to add labels to subplots.
Illustration of its use:
![image](https://github.com/user-attachments/assets/e5dd800b-e800-4a9e-ad3b-6cf9fa0b5bc6)

2. Allow proper processing of AMR-Wind complex terrain sampled data, putting NaNs where the terrain is. This is used for processing of sampled data into VTKs for FAST.Farm