### PR TITLE
[fix] absolute path in setup.py generates errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ EXTRAS = {}
 # Except, perhaps the License and Trove Classifiers!
 # If you do change the License, remember to change the Trove Classifier for that!
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = os.path.relpath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!


### PR DESCRIPTION

> pip install -e .

fails on some platform. the egg SOURCE.txt generated file contains bad absolute  paths.